### PR TITLE
Per level dungeon rarity and custom level support

### DIFF
--- a/LethalLib/Modules/Levels.cs
+++ b/LethalLib/Modules/Levels.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace LethalLib.Modules
 {
-    public class Levels
+    public static class Levels
     {
 
         [Flags]
@@ -22,5 +22,46 @@ namespace LethalLib.Modules
             All = ExperimentationLevel | AssuranceLevel | VowLevel | OffenseLevel | MarchLevel | RendLevel | DineLevel | TitanLevel
         }
 
+        public static bool IsSingleLevel(this LevelTypes levelTypes)
+        {
+            int levelTypesRaw = (int) levelTypes;
+            if (levelTypesRaw == 0)
+            {
+                return false;
+            }
+
+            // https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
+            return (levelTypesRaw & (levelTypesRaw - 1)) == 0;
+        }
+
+        public static List<LevelTypes> ToList(this LevelTypes levelTypes)
+        {
+            List<LevelTypes> types = new List<LevelTypes>();
+            foreach (LevelTypes levelType in Enum.GetValues(typeof(LevelTypes)))
+            {
+                if (levelType == LevelTypes.None || levelType == LevelTypes.All)
+                {
+                    continue;
+                }
+
+                if ((levelTypes & levelType) == levelType)
+                {
+                    types.Add(levelType);
+                }
+            }
+
+            return types;
+        }
+
+        public static LevelTypes FromList(List<LevelTypes> levelTypes)
+        {
+            LevelTypes types = LevelTypes.None;
+            foreach (LevelTypes levelType in levelTypes)
+            {
+                types |= levelType;
+            }
+
+            return types;
+        }
     }
 }


### PR DESCRIPTION
**I noticed you already added custom level support in the dev branch after I made this** (at least that's what I think the `levelOverrides` does) but maybe this could serve as some inspiration for an alternative way of approaching it?

Support for adding dungeons to custom levels and having dungeon rarity on a per level basis.
```cs
// Adding a custom level with rarity
customDungeon.levels.AddLevel("Aquatis", 300);
// Adding a level without the rarity argument uses the default rarity instead 
customDungeon.levels.AddLevel(LevelTypes.All);
// You can get the level and set the rarity (using AddLevel would also overwrite it) 
customDungeon.levels.GetLevel(LevelTypes.AssuranceLevel).rarity = 50;
// Removing the level
customDungeon.levels.RemoveLevel("Aquatis");
```

After adding this I realized this is only half the story since it seems like you don't get direct access to CustomDungeon but adding support for it should be trivial if you think this is something you want! For instance
```cs
var levels = new LethalLib.Modules.Dungeon.CustomDungeonLevels();
levels.AddLevel("Aquatis", 300);
levels.AddLevel(LevelTypes.All);

LethalLib.Modules.Dungeon.AddDungeon(dungeon, levels);
```