### PR TITLE
Fix duplicate map objects being registered.

### DIFF
--- a/LethalLib/Modules/MapObjects.cs
+++ b/LethalLib/Modules/MapObjects.cs
@@ -113,7 +113,7 @@ public class MapObjects
                     {
                         if (mapObject.mapObject != null)
                         {
-                            if (!level.spawnableMapObjects.Any(x => x.prefabToSpawn == mapObject.mapObject.prefabToSpawn))
+                            if (level.spawnableMapObjects.Any(x => x.prefabToSpawn == mapObject.mapObject.prefabToSpawn))
                             {
                                 // remove the object from the list
                                 var list = level.spawnableMapObjects.ToList();

--- a/LethalLib/Modules/MapObjects.cs
+++ b/LethalLib/Modules/MapObjects.cs
@@ -133,7 +133,7 @@ public class MapObjects
                         }
                         else if (mapObject.outsideObject != null)
                         {
-                            if (!level.spawnableOutsideObjects.Any(x => x.spawnableObject.prefabToSpawn == mapObject.outsideObject.spawnableObject.prefabToSpawn))
+                            if (level.spawnableOutsideObjects.Any(x => x.spawnableObject.prefabToSpawn == mapObject.outsideObject.spawnableObject.prefabToSpawn))
                             {
                                 // remove the object from the list
                                 var list = level.spawnableOutsideObjects.ToList();


### PR DESCRIPTION
Looks like two of the .any checks were copy pasted and the ! was not removed. This caused duplicate objects to not trigger the RemoveAll and caused non duplicates to trigger the RemoveAll (and not do anything).