### PR TITLE
Functionality to add custom enemies into the lethal company built in dev mode menu.

### DIFF
--- a/LethalLib/Modules/Enemies.cs
+++ b/LethalLib/Modules/Enemies.cs
@@ -29,16 +29,33 @@ public class Enemies
             return;
         }
         var testLevel = self.testAllEnemiesLevel;
-        var enemies = testLevel.Enemies;
+        var inside = testLevel.Enemies;
+        var daytime = testLevel.DaytimeEnemies;
+        var outside = testLevel.OutsideEnemies;
         foreach (SpawnableEnemy spawnableEnemy in spawnableEnemies)
         {
-            if (enemies.All(x => x.enemyType == spawnableEnemy.enemy)) continue;
-            enemies.Add(new SpawnableEnemyWithRarity
+            if (inside.All(x => x.enemyType == spawnableEnemy.enemy)) continue;
+            SpawnableEnemyWithRarity spawnableEnemyWithRarity = new SpawnableEnemyWithRarity
             {
                 enemyType = spawnableEnemy.enemy,
                 rarity = spawnableEnemy.rarity
-            });
-            Plugin.logger.LogInfo($"Added {spawnableEnemy.enemy.enemyName} to debug list!");
+            };
+            switch (spawnableEnemy.spawnType)
+            {
+                case SpawnType.Default:
+                    if (!inside.Any(x => x.enemyType == spawnableEnemy.enemy))
+                        inside.Add(spawnableEnemyWithRarity);
+                    break;
+                case SpawnType.Daytime:
+                    if (!daytime.Any(x => x.enemyType == spawnableEnemy.enemy))
+                        daytime.Add(spawnableEnemyWithRarity);
+                    break;
+                case SpawnType.Outside:
+                    if (!outside.Any(x => x.enemyType == spawnableEnemy.enemy))
+                        outside.Add(spawnableEnemyWithRarity);
+                    break;
+            }
+            Plugin.logger.LogInfo($"Added {spawnableEnemy.enemy.enemyName} to DebugList [{spawnableEnemy.spawnType}]");
         }
         addedToDebug = true;
         orig(self);

--- a/LethalLib/Modules/Enemies.cs
+++ b/LethalLib/Modules/Enemies.cs
@@ -17,8 +17,33 @@ public class Enemies
     {
         On.StartOfRound.Awake += RegisterLevelEnemies;
         On.Terminal.Start += Terminal_Start;
-
+        On.QuickMenuManager.Start += QuickMenuManager_Start;
     }
+
+    static bool addedToDebug = false; // This method of initializing can be changed to your liking.
+    private static void QuickMenuManager_Start(On.QuickMenuManager.orig_Start orig, QuickMenuManager self)
+    {
+        if (addedToDebug)
+        {
+            orig(self);
+            return;
+        }
+        var testLevel = self.testAllEnemiesLevel;
+        var enemies = testLevel.Enemies;
+        foreach (SpawnableEnemy spawnableEnemy in spawnableEnemies)
+        {
+            if (enemies.All(x => x.enemyType == spawnableEnemy.enemy)) continue;
+            enemies.Add(new SpawnableEnemyWithRarity
+            {
+                enemyType = spawnableEnemy.enemy,
+                rarity = spawnableEnemy.rarity
+            });
+            Plugin.logger.LogInfo($"Added {spawnableEnemy.enemy.enemyName} to debug list!");
+        }
+        addedToDebug = true;
+        orig(self);
+    }
+
     public struct EnemyAssetInfo
     {
         public EnemyType EnemyAsset;

--- a/LethalLib/Modules/NetworkPrefabs.cs
+++ b/LethalLib/Modules/NetworkPrefabs.cs
@@ -17,14 +17,18 @@ public class NetworkPrefabs
 
 
     private static List<GameObject> _networkPrefabs = new List<GameObject>();
+    internal static void Init()
+    {
+        On.GameNetworkManager.Start += GameNetworkManager_Start;
+    }
 
     /// <summary>
     /// Registers a prefab to be added to the network manager.
     /// </summary>
     public static void RegisterNetworkPrefab(GameObject prefab)
     {
-        if(!_networkPrefabs.Contains(prefab))
-            NetworkManager.Singleton.AddNetworkPrefab(prefab);
+        if (!_networkPrefabs.Contains(prefab))
+            _networkPrefabs.Add(prefab);
     }
 
     /// <summary>
@@ -60,4 +64,16 @@ public class NetworkPrefabs
         return prefab;
     }
 
+
+    private static void GameNetworkManager_Start(On.GameNetworkManager.orig_Start orig, GameNetworkManager self)
+    {
+        orig(self);
+
+        foreach (GameObject obj in _networkPrefabs)
+        {
+            if (!NetworkManager.Singleton.NetworkConfig.Prefabs.Contains(obj))
+                NetworkManager.Singleton.AddNetworkPrefab(obj);
+        }
+
+    }
 }


### PR DESCRIPTION
What changed:
* `NetworkPrefabs.cs` - I took the network prefab code from the dev branch because of possibly outdated code from the main branch.
* `Enemies.cs` - Added a hook to `QuickMenuManager_Start`, which is what adds in enemies to the dev mode menu.

The way I'm checking if `addedToDebug` is `true` can be changed to a different method of checking whether the enemies have been added to the menu.