### PR TITLE
Add NetworkPrefabs.Init() back to Plugin.cs

### DIFF
--- a/LethalLib/Plugin.cs
+++ b/LethalLib/Plugin.cs
@@ -51,6 +51,7 @@ public class Plugin : BaseUnityPlugin
         Weathers.Init();
         Player.Init();
         Utilities.Init();
+        NetworkPrefabs.Init();
     }
 
     private void IlHook(ILContext il)


### PR DESCRIPTION
- A mistake was made in this commit: https://github.com/EvaisaDev/LethalLib/commit/8469f19a2f2cf00464c632d4d168abd4bba76ed2
which removed `NetworkPrefabs.Init();` in Plugin.cs, causing Network Prefabs to never be registered.

This is the root cause of v1.4.0s issues.