### PR TITLE
Fix Enemy Registration with Rarity Tables

### DIFF
--- a/LethalLib/Modules/Enemies.cs
+++ b/LethalLib/Modules/Enemies.cs
@@ -170,7 +170,7 @@ public class Enemies
                 {
                     var levelEnum = alwaysValid ? Levels.LevelTypes.All : (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
 
-                    if (alwaysValid || spawnableEnemy.spawnLevels.HasFlag(levelEnum))
+                    if (alwaysValid || spawnableEnemy.levelRarities.ContainsKey(levelEnum))
                     {
                         // find rarity
                         int rarity = 0;
@@ -402,6 +402,9 @@ public class Enemies
         var callingAssembly = Assembly.GetCallingAssembly();
         var modDLL = callingAssembly.GetName().Name;
         spawnableEnemy.modName = modDLL;
+
+
+        spawnableEnemies.Add(spawnableEnemy);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes https://github.com/EvaisaDev/LethalLib/issues/64 by doing the following:

- Adds the Enemy to `spawnableEnemies`
- Uses `levelRarities` list instead of `spawnLevels` for finding out if the enemy should be added to a level
    - This is because `spawnLevels` is never set when registering using Rarity Tables