### PR TITLE
Add Null Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## LethalLib [0.14.4]
+
+### Fixed
+- Added various null checks to prevent crashes and to give better feedback to developers when using custom enemy API.
+
+## LethalLib [0.14.3]
+
+### Fixed
+- API for enemy registration with rarity tables works now.
+
 ## LethalLib [0.14.2]
 
 ### Changed

--- a/LethalLib/Modules/Enemies.cs
+++ b/LethalLib/Modules/Enemies.cs
@@ -337,6 +337,7 @@ public class Enemies
     /// </summary>
     public static void RegisterEnemy(EnemyType enemy, int rarity, Levels.LevelTypes levelFlags, SpawnType spawnType, string[] spawnLevelOverrides = null, TerminalNode infoNode = null, TerminalKeyword infoKeyword = null)
     {
+        EnemyNullCheck(enemy);
         // if already registered, add rarity to levelRarities
         var spawnableEnemy = spawnableEnemies.FirstOrDefault(x => x.enemy == enemy && x.spawnType == spawnType);
 
@@ -370,6 +371,7 @@ public class Enemies
     /// </summary>
     public static void RegisterEnemy(EnemyType enemy, SpawnType spawnType, Dictionary<Levels.LevelTypes, int>? levelRarities = null, Dictionary<string, int>? customLevelRarities = null, TerminalNode infoNode = null, TerminalKeyword infoKeyword = null)
     {
+        EnemyNullCheck(enemy);
         // if already registered, add rarity to levelRarities
         var spawnableEnemy = spawnableEnemies.FirstOrDefault(x => x.enemy == enemy && x.spawnType == spawnType);
 
@@ -422,12 +424,20 @@ public class Enemies
         spawnableEnemies.Add(spawnableEnemy);
     }
 
+    private static void EnemyNullCheck(EnemyType enemy)
+    {
+        if (enemy is null) {
+            throw new ArgumentNullException(nameof(enemy), $"The first argument of {nameof(RegisterEnemy)} was null!");
+        }
+    }
+
     /// <summary>
     /// Registers a enemy to be added to the given levels.
     /// Automatically sets the spawnType based on the enemy's isDaytimeEnemy and isOutsideEnemy properties.
     /// </summary>
     public static void RegisterEnemy(EnemyType enemy, int rarity, Levels.LevelTypes levelFlags, TerminalNode infoNode = null, TerminalKeyword infoKeyword = null)
     {
+        EnemyNullCheck(enemy);
         var spawnType = enemy.isDaytimeEnemy ? SpawnType.Daytime : enemy.isOutsideEnemy ? SpawnType.Outside : SpawnType.Default;
 
         RegisterEnemy(enemy, rarity, levelFlags, spawnType, null, infoNode, infoKeyword);
@@ -439,6 +449,7 @@ public class Enemies
     /// </summary>
     public static void RegisterEnemy(EnemyType enemy, int rarity, Levels.LevelTypes levelFlags, string[] spawnLevelOverrides = null, TerminalNode infoNode = null, TerminalKeyword infoKeyword = null)
     {
+        EnemyNullCheck(enemy);
         var spawnType = enemy.isDaytimeEnemy ? SpawnType.Daytime : enemy.isOutsideEnemy ? SpawnType.Outside : SpawnType.Default;
 
         RegisterEnemy(enemy, rarity, levelFlags, spawnType, spawnLevelOverrides, infoNode, infoKeyword);
@@ -450,6 +461,7 @@ public class Enemies
     /// </summary>
     public static void RegisterEnemy(EnemyType enemy, Dictionary<Levels.LevelTypes, int>? levelRarities = null, Dictionary<string, int>? customLevelRarities = null, TerminalNode infoNode = null, TerminalKeyword infoKeyword = null)
     {
+        EnemyNullCheck(enemy);
         var spawnType = enemy.isDaytimeEnemy ? SpawnType.Daytime : enemy.isOutsideEnemy ? SpawnType.Outside : SpawnType.Default;
 
         RegisterEnemy(enemy, spawnType, levelRarities, customLevelRarities, infoNode, infoKeyword);

--- a/LethalLib/Modules/Enemies.cs
+++ b/LethalLib/Modules/Enemies.cs
@@ -411,11 +411,11 @@ public class Enemies
             throw new NullReferenceException($"Cannot register enemy '{spawnableEnemy.enemy.enemyName}', because enemy.enemyPrefab is null!");
         }
 
-        var collisionComponents = spawnableEnemy.enemy.enemyPrefab.GetComponentsInChildren<EnemyAICollisionDetect>();
-        foreach (var collisionObject in collisionComponents)
+        var collisionDetectComponents = spawnableEnemy.enemy.enemyPrefab.GetComponentsInChildren<EnemyAICollisionDetect>();
+        foreach (var collisionDetectComponent in collisionDetectComponents)
         {
-            if (collisionObject.mainScript is null) {
-                Plugin.logger.LogError($"An Enemy AI Collision Detect Script on GameObject '{collisionObject.gameObject.name}' of enemy '{spawnableEnemy.enemy.enemyName}' does not reference a 'Main Script', and will cause errors!");
+            if (collisionDetectComponent.mainScript is null) {
+                Plugin.logger.LogError($"An Enemy AI Collision Detect Script on GameObject '{collisionDetectComponent.gameObject.name}' of enemy '{spawnableEnemy.enemy.enemyName}' does not reference a 'Main Script', and will cause errors!");
             }
         }
 

--- a/LethalLib/Modules/Enemies.cs
+++ b/LethalLib/Modules/Enemies.cs
@@ -132,7 +132,11 @@ public class Enemies
 
             self.enemyFiles.Add(spawnableEnemy.terminalNode);
 
-            spawnableEnemy.enemy.enemyPrefab.GetComponentInChildren<ScanNodeProperties>().creatureScanID = spawnableEnemy.terminalNode.creatureFileID;
+            var scanNodePropertyComponents = spawnableEnemy.enemy.enemyPrefab.GetComponentsInChildren<ScanNodeProperties>();
+            for (int i = 0; i < scanNodePropertyComponents.Length; i++)
+            {
+                scanNodePropertyComponents[i].creatureScanID = spawnableEnemy.terminalNode.creatureFileID;
+            }
 
             var enemyAssetInfo = new EnemyAssetInfo()
             {
@@ -358,12 +362,7 @@ public class Enemies
         spawnableEnemy.terminalNode = infoNode;
         spawnableEnemy.infoKeyword = infoKeyword;
 
-        var callingAssembly = Assembly.GetCallingAssembly();
-        var modDLL = callingAssembly.GetName().Name;
-        spawnableEnemy.modName = modDLL;
-
-
-        spawnableEnemies.Add(spawnableEnemy);
+        FinalizeRegisterEnemy(spawnableEnemy);
     }
 
     /// <summary>
@@ -399,10 +398,26 @@ public class Enemies
         spawnableEnemy.terminalNode = infoNode;
         spawnableEnemy.infoKeyword = infoKeyword;
 
+        FinalizeRegisterEnemy(spawnableEnemy);
+    }
+
+    private static void FinalizeRegisterEnemy(SpawnableEnemy spawnableEnemy)
+    {
         var callingAssembly = Assembly.GetCallingAssembly();
         var modDLL = callingAssembly.GetName().Name;
         spawnableEnemy.modName = modDLL;
 
+        if (spawnableEnemy.enemy.enemyPrefab is null) {
+            throw new NullReferenceException($"Cannot register enemy '{spawnableEnemy.enemy.enemyName}', because enemy.enemyPrefab is null!");
+        }
+
+        var collisionComponents = spawnableEnemy.enemy.enemyPrefab.GetComponentsInChildren<EnemyAICollisionDetect>();
+        foreach (var collisionObject in collisionComponents)
+        {
+            if (collisionObject.mainScript is null) {
+                Plugin.logger.LogError($"An Enemy AI Collision Detect Script on GameObject '{collisionObject.gameObject.name}' of enemy '{spawnableEnemy.enemy.enemyName}' does not reference a 'Main Script', and will cause errors!");
+            }
+        }
 
         spawnableEnemies.Add(spawnableEnemy);
     }

--- a/LethalLib/Modules/NetworkPrefabs.cs
+++ b/LethalLib/Modules/NetworkPrefabs.cs
@@ -27,6 +27,8 @@ public class NetworkPrefabs
     /// </summary>
     public static void RegisterNetworkPrefab(GameObject prefab)
     {
+        if (prefab is null)
+            throw new NullReferenceException($"Cannot register a null Prefab as a Network Prefab!");
         if (!_networkPrefabs.Contains(prefab))
             _networkPrefabs.Add(prefab);
     }

--- a/LethalLib/Modules/NetworkPrefabs.cs
+++ b/LethalLib/Modules/NetworkPrefabs.cs
@@ -28,7 +28,7 @@ public class NetworkPrefabs
     public static void RegisterNetworkPrefab(GameObject prefab)
     {
         if (prefab is null)
-            throw new NullReferenceException($"Cannot register a null Prefab as a Network Prefab!");
+            throw new ArgumentNullException(nameof(prefab), $"The given argument for {nameof(RegisterNetworkPrefab)} is null!");
         if (!_networkPrefabs.Contains(prefab))
             _networkPrefabs.Add(prefab);
     }


### PR DESCRIPTION
Enemies:
- Check for missing `ScanNodeProperties`
    - Would have crashed `Terminal_Start`
    - An enemy can now also have multiple game objects with `ScanNodeProperties`
- Check if `EnemyType enemy` of `RegisterEnemy` is null
    - Throw `ArgumentNullException`
- Check if `enemyPrefab` is null
    - Throw `NullReferenceException`
    - Would also have crashed `Terminal_Start`
- Check if an `EnemyAICollisionDetect` Script's `mainScript` reference is null
    - Print an error as a warning, as this will result in errors during gameplay
    - This is a really common mistake, so having this check will be useful

NetworkPrefabs:
- Check if `prefab` of `RegisterNetworkPrefab` is null
    - Throw `ArgumentNullException`