### PR TITLE
Fix `StackFrame.AddFrames` patch fails if other mod patches it

### DIFF
--- a/LethalLib/Plugin.cs
+++ b/LethalLib/Plugin.cs
@@ -61,11 +61,13 @@ public class Plugin : BaseUnityPlugin
     private void IlHook(ILContext il)
     {
         var cursor = new ILCursor(il);
-        cursor.GotoNext(
-            x => x.MatchCallvirt(typeof(StackFrame).GetMethod("GetFileLineNumber", BindingFlags.Instance | BindingFlags.Public))
-        );
-        cursor.RemoveRange(2);
-        cursor.EmitDelegate<Func<StackFrame, string>>(GetLineOrIL);
+        var getFileLineNumberMethod = typeof(StackFrame).GetMethod("GetFileLineNumber", BindingFlags.Instance | BindingFlags.Public);
+
+        if (cursor.TryGotoNext(x => x.MatchCallvirt(getFileLineNumberMethod)))
+        {
+            cursor.RemoveRange(2);
+            cursor.EmitDelegate<Func<StackFrame, string>>(GetLineOrIL);
+        }
     }
 
     private static string GetLineOrIL(StackFrame instance)


### PR DESCRIPTION
Fixes this exception if other mods (like [BepInEx_MonoMod_Debug_Patcher](https://thunderstore.io/c/lethal-company/p/DiFFoZ/BepInEx_MonoMod_Debug_Patcher/)) patches the `StackFrame.AddFrames`.
```
KeyNotFoundException: The given key was not present in the dictionary.
  at MonoMod.Cil.ILCursor.GotoNext (MonoMod.Cil.MoveType moveType, System.Func`2[Mono.Cecil.Cil.Instruction,System.Boolean][] predicates) [0x0000a] in <6733e342b5b549bba815373898724469>:0 
  at MonoMod.Cil.ILCursor.GotoNext (System.Func`2[Mono.Cecil.Cil.Instruction,System.Boolean][] predicates) [0x00000] in <6733e342b5b549bba815373898724469>:0 
  at LethalLib.Plugin.IlHook (MonoMod.Cil.ILContext il) [0x00007] in <c68aa40cbbae4bd69cd2fcd50c8f1ae1>:0 
  at MonoMod.Cil.ILContext.Invoke (MonoMod.Cil.ILContext+Manipulator manip) [0x00087] in <6733e342b5b549bba815373898724469>:0 
  at MonoMod.RuntimeDetour.ILHook+Context.InvokeManipulator (Mono.Cecil.MethodDefinition def, MonoMod.Cil.ILContext+Manipulator cb) [0x00012] in <4e2760c7517c4ea79c633d67e84b319f>:0 
  at (wrapper dynamic-method) MonoMod.RuntimeDetour.ILHook+Context.DMD<MonoMod.RuntimeDetour.ILHook+Context::Refresh>(MonoMod.RuntimeDetour.ILHook/Context)
  at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.Trampoline<MonoMod.RuntimeDetour.ILHook+Context::Refresh>?373559048(object)
  at HarmonyLib.Internal.RuntimeFixes.StackTraceFixes.OnILChainRefresh (System.Object self) [0x00000] in <474744d65d8e460fa08cd5fd82b5d65f>:0 
  at MonoMod.RuntimeDetour.ILHook.Apply () [0x00059] in <4e2760c7517c4ea79c633d67e84b319f>:0 
  at MonoMod.RuntimeDetour.ILHook..ctor (System.Reflection.MethodBase from, MonoMod.Cil.ILContext+Manipulator manipulator, MonoMod.RuntimeDetour.ILHookConfig& config) [0x00148] in <4e2760c7517c4ea79c633d67e84b319f>:0 
  at MonoMod.RuntimeDetour.ILHook..ctor (System.Reflection.MethodBase from, MonoMod.Cil.ILContext+Manipulator manipulator, MonoMod.RuntimeDetour.ILHookConfig config) [0x00000] in <4e2760c7517c4ea79c633d67e84b319f>:0 
  at MonoMod.RuntimeDetour.ILHook..ctor (System.Reflection.MethodBase from, MonoMod.Cil.ILContext+Manipulator manipulator) [0x0001c] in <4e2760c7517c4ea79c633d67e84b319f>:0 
  at LethalLib.Plugin.Awake () [0x00086] in <c68aa40cbbae4bd69cd2fcd50c8f1ae1>:0 
```