### PR TITLE
Add a reference to LevelWeatherType enum hook

### DIFF
--- a/LethalLib/Modules/Weathers.cs
+++ b/LethalLib/Modules/Weathers.cs
@@ -36,6 +36,7 @@ public class Weathers
     public static int numCustomWeathers = 0;
     // public static Array newWeatherValuesArray;
     //public static string[] newWeatherNamesArray;
+    private static Hook? weatherEnumHook ;
 
     public static void Init()
     {
@@ -54,7 +55,7 @@ public class Weathers
         }), typeof(Weathers).GetMethod("GetNamesHook"));*/
 
         //public override string ToString();
-        new Hook(typeof(Enum).GetMethod("ToString", new Type[]
+        weatherEnumHook = new Hook(typeof(Enum).GetMethod("ToString", new Type[]
         {
         }), typeof(Weathers).GetMethod("ToStringHook"));
 


### PR DESCRIPTION
This commit adds a field to `LethalLib.Modules.Weather` class for easier referencing of the MonoMod detour.

My intention is to build a custom weather loader that's backwards-compatible with LethalLib, and because of the two mods having to patch the LevelWeatherType enum to extend it, this will make it easier to reference the patch and override it.