### PR TITLE
Create dynamic enums using Enum Utils instead of using numbers and a ToString hook

### DIFF
--- a/LethalLib/LethalLib.csproj
+++ b/LethalLib/LethalLib.csproj
@@ -34,6 +34,7 @@
     <ItemGroup>
         <PackageReference Include="BepInEx.Core" Version="5.4.21" />
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" PrivateAssets="all"/>
+        <PackageReference Include="MegaPiggy.LCEnumUtils" Version="1.0.5" />
         <Reference Include="Assembly-CSharp">
             <HintPath>$(LethalCompanyDir)Lethal Company_Data/Managed/Assembly-CSharp.dll</HintPath>
         </Reference>

--- a/LethalLib/Modules/Dungeon.cs
+++ b/LethalLib/Modules/Dungeon.cs
@@ -67,16 +67,16 @@ public class Dungeon
             {
                 var name = level.name;
                 var alwaysValid = dungeon.LevelTypes.HasFlag(Levels.LevelTypes.All) || (dungeon.levelOverrides != null && dungeon.levelOverrides.Any(item => item.ToLowerInvariant() == name.ToLowerInvariant()));
-                var isModded = dungeon.LevelTypes.HasFlag(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+                var isModded = dungeon.LevelTypes.HasFlag(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
 
                 if (isModded)
                 {
                     alwaysValid = true;
                 }
 
-                if (Enum.IsDefined(typeof(Levels.LevelTypes), name) || alwaysValid)
+                if (EnumUtils.IsDefined<Levels.LevelTypes>(name) || alwaysValid)
                 {
-                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : EnumUtils.Parse<Levels.LevelTypes>(name);
 
                     if ((alwaysValid || dungeon.LevelTypes.HasFlag(levelEnum)) && !level.dungeonFlowTypes.Any(rarityInt => rarityInt.id == dungeon.dungeonIndex))
                     {
@@ -123,9 +123,9 @@ public class Dungeon
     private static void RoundManager_GenerateNewFloor(On.RoundManager.orig_GenerateNewFloor orig, RoundManager self)
     {
         var name = self.currentLevel.name;
-        if (Enum.IsDefined(typeof(Levels.LevelTypes), name))
+        if (EnumUtils.IsDefined<Levels.LevelTypes>(name))
         {
-            var levelEnum = (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+            var levelEnum = EnumUtils.Parse<Levels.LevelTypes>(name);
 
             var index = 0;
             self.dungeonGenerator.Generator.DungeonFlow.Lines.ForEach((line) =>

--- a/LethalLib/Modules/Enemies.cs
+++ b/LethalLib/Modules/Enemies.cs
@@ -195,11 +195,11 @@ public class Enemies
         var name = level.name;
 
         //var alwaysValid = spawnableEnemy.spawnLevels.HasFlag(Levels.LevelTypes.All) || (spawnableEnemy.spawnLevelOverrides != null && spawnableEnemy.spawnLevelOverrides.Any(item => item.ToLowerInvariant() == name.ToLowerInvariant()));
-        //var isModded = spawnableEnemy.spawnLevels.HasFlag(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+        //var isModded = spawnableEnemy.spawnLevels.HasFlag(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
         var alwaysValid = spawnableEnemy.levelRarities.ContainsKey(Levels.LevelTypes.All)
             || spawnableEnemy.levelRarities.ContainsKey(Levels.LevelTypes.Vanilla)
             || (spawnableEnemy.customLevelRarities != null && spawnableEnemy.customLevelRarities.ContainsKey(name));
-        var isModded = spawnableEnemy.levelRarities.ContainsKey(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+        var isModded = spawnableEnemy.levelRarities.ContainsKey(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
 
 
         if (isModded)
@@ -210,8 +210,8 @@ public class Enemies
         var realLevelEnum = Levels.LevelTypes.None;
         bool isVanilla = false;
 
-        if(Enum.IsDefined(typeof(Levels.LevelTypes), name)){
-            realLevelEnum = (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+        if(EnumUtils.IsDefined<Levels.LevelTypes>(name)){
+            realLevelEnum = EnumUtils.Parse<Levels.LevelTypes>(name);
             isVanilla = true;
         }
         else
@@ -346,7 +346,7 @@ public class Enemies
 
             if (spawnLevels != Levels.LevelTypes.None)
             {
-                foreach (Levels.LevelTypes level in Enum.GetValues(typeof(Levels.LevelTypes)))
+                foreach (Levels.LevelTypes level in EnumUtils.GetValues<Levels.LevelTypes>())
                 {
                     if (spawnLevels.HasFlag(level))
                     {
@@ -531,20 +531,20 @@ public class Enemies
             {
                 var name = level.name;
 
-                if(!Enum.IsDefined(typeof(Levels.LevelTypes), name))
+                if(!EnumUtils.IsDefined<Levels.LevelTypes>(name))
                     name = Levels.Compatibility.GetLLLNameOfLevel(name);
                                 
                 var alwaysValid = levelFlags.HasFlag(Levels.LevelTypes.All) || (levelOverrides != null && levelOverrides.Any(item => Levels.Compatibility.GetLLLNameOfLevel(item).ToLowerInvariant() == name.ToLowerInvariant()));
-                var isModded = levelFlags.HasFlag(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+                var isModded = levelFlags.HasFlag(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
 
                 if (isModded)
                 {
                     alwaysValid = true;
                 }
 
-                if (Enum.IsDefined(typeof(Levels.LevelTypes), name) || alwaysValid)
+                if (EnumUtils.IsDefined<Levels.LevelTypes>(name) || alwaysValid)
                 {
-                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : EnumUtils.Parse<Levels.LevelTypes>(name);
                     if (alwaysValid || levelFlags.HasFlag(levelEnum))
                     {
 

--- a/LethalLib/Modules/Items.cs
+++ b/LethalLib/Modules/Items.cs
@@ -182,7 +182,7 @@ public class Items
         var alwaysValid = scrapItem.levelRarities.ContainsKey(Levels.LevelTypes.All)
             || scrapItem.levelRarities.ContainsKey(Levels.LevelTypes.Vanilla)
             || (scrapItem.customLevelRarities != null && scrapItem.customLevelRarities.ContainsKey(name));
-        var isModded = scrapItem.levelRarities.ContainsKey(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+        var isModded = scrapItem.levelRarities.ContainsKey(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
 
         if (isModded)
         {
@@ -192,8 +192,8 @@ public class Items
         var realLevelEnum = Levels.LevelTypes.None;
         bool isVanilla = false;
         
-        if(Enum.IsDefined(typeof(Levels.LevelTypes), name)){
-            realLevelEnum = (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+        if(EnumUtils.IsDefined<Levels.LevelTypes>(name)){
+            realLevelEnum = EnumUtils.Parse<Levels.LevelTypes>(name);
             isVanilla = true;
         }
         else
@@ -201,7 +201,7 @@ public class Items
 
         if (isVanilla || alwaysValid)
         {
-            var levelEnum = alwaysValid ? Levels.LevelTypes.All : (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+            var levelEnum = alwaysValid ? Levels.LevelTypes.All : EnumUtils.Parse<Levels.LevelTypes>(name);
 
             // old: scrapItem.spawnLevels.HasFlag(levelEnum)
             if (alwaysValid || scrapItem.levelRarities.ContainsKey(levelEnum))
@@ -582,7 +582,7 @@ public class Items
 
             if (spawnLevels != Levels.LevelTypes.None)
             {
-                foreach (Levels.LevelTypes level in Enum.GetValues(typeof(Levels.LevelTypes)))
+                foreach (Levels.LevelTypes level in EnumUtils.GetValues<Levels.LevelTypes>())
                 {
                     if (spawnLevels.HasFlag(level))
                     {
@@ -862,20 +862,20 @@ public class Items
             {
                 var name = level.name;
 
-                if(!Enum.IsDefined(typeof(Levels.LevelTypes), name))
+                if(!EnumUtils.IsDefined<Levels.LevelTypes>(name))
                     name = Levels.Compatibility.GetLLLNameOfLevel(name);
 
                 var alwaysValid = levelFlags.HasFlag(Levels.LevelTypes.All) || (levelOverrides != null && levelOverrides.Any(item => Levels.Compatibility.GetLLLNameOfLevel(item).ToLowerInvariant() == name.ToLowerInvariant()));
-                var isModded = levelFlags.HasFlag(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+                var isModded = levelFlags.HasFlag(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
 
                 if (isModded)
                 {
                     alwaysValid = true;
                 }
 
-                if (Enum.IsDefined(typeof(Levels.LevelTypes), name) || alwaysValid)
+                if (EnumUtils.IsDefined<Levels.LevelTypes>(name) || alwaysValid)
                 {
-                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : EnumUtils.Parse<Levels.LevelTypes>(name);
                     if (alwaysValid || levelFlags.HasFlag(levelEnum))
                     {
                         // find item in scrapItems

--- a/LethalLib/Modules/MapObjects.cs
+++ b/LethalLib/Modules/MapObjects.cs
@@ -97,16 +97,16 @@ public class MapObjects
             {
                 var name = level.name;
                 var alwaysValid = mapObject.levels.HasFlag(Levels.LevelTypes.All) || (mapObject.spawnLevelOverrides != null && mapObject.spawnLevelOverrides.Any(item => item.ToLowerInvariant() == name.ToLowerInvariant()));
-                var isModded = mapObject.levels.HasFlag(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+                var isModded = mapObject.levels.HasFlag(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
 
                 if (isModded)
                 {
                     alwaysValid = true;
                 }
 
-                if (Enum.IsDefined(typeof(Levels.LevelTypes), name) || alwaysValid)
+                if (EnumUtils.IsDefined<Levels.LevelTypes>(name) || alwaysValid)
                 {
-                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : EnumUtils.Parse<Levels.LevelTypes>(name);
 
 
                     if (alwaysValid || mapObject.levels.HasFlag(levelEnum))
@@ -278,15 +278,15 @@ public class MapObjects
                 var name = level.name;
 
                 var alwaysValid = levelFlags.HasFlag(Levels.LevelTypes.All) || (levelOverrides != null && levelOverrides.Any(item => item.ToLowerInvariant() == name.ToLowerInvariant()));
-                var isModded = levelFlags.HasFlag(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+                var isModded = levelFlags.HasFlag(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
 
                 if (isModded)
                 {
                     alwaysValid = true;
                 }
-                if (Enum.IsDefined(typeof(Levels.LevelTypes), name) || alwaysValid)
+                if (EnumUtils.IsDefined<Levels.LevelTypes>(name) || alwaysValid)
                 {
-                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : EnumUtils.Parse<Levels.LevelTypes>(name);
                     if (alwaysValid || levelFlags.HasFlag(levelEnum))
                     {
 
@@ -317,15 +317,15 @@ public class MapObjects
                 var name = level.name;
 
                 var alwaysValid = levelFlags.HasFlag(Levels.LevelTypes.All) || (levelOverrides != null && levelOverrides.Any(item => item.ToLowerInvariant() == name.ToLowerInvariant()));
-                var isModded = levelFlags.HasFlag(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+                var isModded = levelFlags.HasFlag(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
 
                 if (isModded)
                 {
                     alwaysValid = true;
                 }
-                if (Enum.IsDefined(typeof(Levels.LevelTypes), name) || alwaysValid)
+                if (EnumUtils.IsDefined<Levels.LevelTypes>(name) || alwaysValid)
                 {
-                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+                    var levelEnum = alwaysValid ? Levels.LevelTypes.All : EnumUtils.Parse<Levels.LevelTypes>(name);
                     if (alwaysValid || levelFlags.HasFlag(levelEnum))
                     {
 

--- a/LethalLib/Modules/Weathers.cs
+++ b/LethalLib/Modules/Weathers.cs
@@ -102,16 +102,16 @@ public class Weathers
         var name = level.name;
 
         var alwaysValid = entry.Value.levels.HasFlag(Levels.LevelTypes.All) || (entry.Value.spawnLevelOverrides != null && entry.Value.spawnLevelOverrides.Any(item => item.ToLowerInvariant() == name.ToLowerInvariant()));
-        var isModded = entry.Value.levels.HasFlag(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+        var isModded = entry.Value.levels.HasFlag(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
 
         if (isModded)
         {
             alwaysValid = true;
         }
 
-        if (Enum.IsDefined(typeof(Levels.LevelTypes), name) || alwaysValid)
+        if (EnumUtils.IsDefined<Levels.LevelTypes>(name) || alwaysValid)
         {
-            var levelEnum = alwaysValid ? Levels.LevelTypes.All : (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+            var levelEnum = alwaysValid ? Levels.LevelTypes.All : EnumUtils.Parse<Levels.LevelTypes>(name);
             var weathers = level.randomWeathers.ToList();
             // loop through custom weathers
 
@@ -265,15 +265,15 @@ public class Weathers
                     var name = level.name;
 
                     var alwaysValid = levelFlags.HasFlag(Levels.LevelTypes.All) || (levelOverrides != null && levelOverrides.Any(item => item.ToLowerInvariant() == name.ToLowerInvariant()));
-                    var isModded = levelFlags.HasFlag(Levels.LevelTypes.Modded) && !Enum.IsDefined(typeof(Levels.LevelTypes), name);
+                    var isModded = levelFlags.HasFlag(Levels.LevelTypes.Modded) && !EnumUtils.IsDefined<Levels.LevelTypes>(name);
 
                     if (isModded)
                     {
                         alwaysValid = true;
                     }
-                    if (Enum.IsDefined(typeof(Levels.LevelTypes), name) || alwaysValid)
+                    if (EnumUtils.IsDefined<Levels.LevelTypes>(name) || alwaysValid)
                     {
-                        var levelEnum = alwaysValid ? Levels.LevelTypes.All : (Levels.LevelTypes)Enum.Parse(typeof(Levels.LevelTypes), name);
+                        var levelEnum = alwaysValid ? Levels.LevelTypes.All : EnumUtils.Parse<Levels.LevelTypes>(name);
                         if (alwaysValid || levelFlags.HasFlag(levelEnum))
                         {
                             var weathers = level.randomWeathers.ToList();

--- a/LethalLib/Plugin.cs
+++ b/LethalLib/Plugin.cs
@@ -18,6 +18,7 @@ using UnityEngine;
 namespace LethalLib;
 
 [BepInPlugin(ModGUID, ModName, ModVersion)]
+[BepInDependency(LCEnumUtils.PluginInfo.ModGUID)]
 //[BepInDependency("LethalExpansion", BepInDependency.DependencyFlags.SoftDependency)]
 public class Plugin : BaseUnityPlugin
 {

--- a/LethalLib/assets/thunderstore.toml
+++ b/LethalLib/assets/thunderstore.toml
@@ -13,6 +13,7 @@ containsNsfwContent = false
 [package.dependencies]
 BepInEx-BepInExPack = "5.4.2100"
 Evaisa-HookGenPatcher = "0.0.5"
+MegaPiggy-EnumUtils = "1.0.5"
 
 [build]
 icon = "icons/lethal-lib.png"


### PR DESCRIPTION
Adds [Enum Utils](https://thunderstore.io/c/lethal-company/p/MegaPiggy/EnumUtils) as a library dependency

Main commit is this one https://github.com/EvaisaDev/LethalLib/commit/0721fc25ffb707022b86b153edd19ab56f446143 that changes weather so that it makes an enum that other mods can interact with, and stop collisions between mods if they are using this library. 

(also made lethal lib use enum utils in other places so it looks a little cleaner with less casts)

The way creating an enum works in my library is that it will find the first free value and assign the name you give it to that value.
This also means you can use any System.Enum method and the modded enums will show up.

Hopefully you have no problems with me making this pr
Let me know if you want me to change anything with this pr or my library

I'm just trying to make Enum Utils a standard library to go for when messing with enums like weather, cause of death, and etc since it seems people just had no idea it existed for 6 months.