### PR TITLE
Fix MapObjects `spawnRateFunction` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## LethalLib [0.16.2]
+
+### Fixed
+- The last return value of `spawnRateFunction` of MapObjects no longer overwrites a map object's spawn curve for each moon.
+
 ## LethalLib [0.16.1]
 
 ### Fixed

--- a/LethalLib/Modules/MapObjects.cs
+++ b/LethalLib/Modules/MapObjects.cs
@@ -113,22 +113,35 @@ public class MapObjects
                     {
                         if (mapObject.mapObject != null)
                         {
+                            // Remove existing object if it exists
                             if (level.spawnableMapObjects.Any(x => x.prefabToSpawn == mapObject.mapObject.prefabToSpawn))
                             {
-                                // remove the object from the list
                                 var list = level.spawnableMapObjects.ToList();
                                 list.RemoveAll(x => x.prefabToSpawn == mapObject.mapObject.prefabToSpawn);
                                 level.spawnableMapObjects = list.ToArray();
                             }
 
-                            SpawnableMapObject spawnableMapObject = mapObject.mapObject;
+                            // Create a new instance so it can have its own `numberToSpawn` value
+                            SpawnableMapObject spawnableMapObject = new()
+                            {
+                                prefabToSpawn = mapObject.mapObject.prefabToSpawn,
+                                spawnFacingAwayFromWall = mapObject.mapObject.spawnFacingAwayFromWall,
+                                spawnFacingWall = mapObject.mapObject.spawnFacingWall,
+                                spawnWithBackToWall = mapObject.mapObject.spawnWithBackToWall,
+                                spawnWithBackFlushAgainstWall = mapObject.mapObject.spawnWithBackFlushAgainstWall,
+                                requireDistanceBetweenSpawns = mapObject.mapObject.requireDistanceBetweenSpawns,
+                                disallowSpawningNearEntrances = mapObject.mapObject.disallowSpawningNearEntrances,
+                            };
+
                             if (mapObject.spawnRateFunction != null)
                             {
                                 spawnableMapObject.numberToSpawn = mapObject.spawnRateFunction(level);
                             }
+
                             var mapObjectsList = level.spawnableMapObjects.ToList();
                             mapObjectsList.Add(spawnableMapObject);
                             level.spawnableMapObjects = mapObjectsList.ToArray();
+
                             if (Plugin.extendedLogging.Value)
                                 Plugin.logger.LogInfo($"Added {spawnableMapObject.prefabToSpawn.name} to {name}");
                         }
@@ -136,25 +149,29 @@ public class MapObjects
                         {
                             if (level.spawnableOutsideObjects.Any(x => x.spawnableObject.prefabToSpawn == mapObject.outsideObject.spawnableObject.prefabToSpawn))
                             {
-                                // remove the object from the list
                                 var list = level.spawnableOutsideObjects.ToList();
                                 list.RemoveAll(x => x.spawnableObject.prefabToSpawn == mapObject.outsideObject.spawnableObject.prefabToSpawn);
                                 level.spawnableOutsideObjects = list.ToArray();
                             }
 
-                            SpawnableOutsideObjectWithRarity spawnableOutsideObject = mapObject.outsideObject;
+                            SpawnableOutsideObjectWithRarity spawnableOutsideObject = new()
+                            {
+                                spawnableObject = mapObject.outsideObject.spawnableObject
+                            };
+
                             if (mapObject.spawnRateFunction != null)
                             {
                                 spawnableOutsideObject.randomAmount = mapObject.spawnRateFunction(level);
                             }
+
                             var mapObjectsList = level.spawnableOutsideObjects.ToList();
                             mapObjectsList.Add(spawnableOutsideObject);
                             level.spawnableOutsideObjects = mapObjectsList.ToArray();
+
                             if (Plugin.extendedLogging.Value)
                                 Plugin.logger.LogInfo($"Added {spawnableOutsideObject.spawnableObject.prefabToSpawn.name} to {name}");
                         }
                     }
-
                 }
             }
         }


### PR DESCRIPTION
> ### Fixed
> - The last return value of `spawnRateFunction` of MapObjects no longer overwrites a map object's spawn curve for each moon.