### PR TITLE
AddEnemyToLevel was ignoring custom levels if nothing else other than them were present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## LethalLib [0.16.4]
+- Fixed `AddEnemyToLevel` needing a `LevelType` to validate custom moon enemy rarities.
+
 ## LethalLib [0.16.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## LethalLib [0.16.4]
 - Fixed `AddEnemyToLevel` needing a `LevelType` to validate custom moon enemy rarities.
+- Fixed `AddScrapItemToLevel` having the same issue as above.
 
 ## LethalLib [0.16.3]
 


### PR DESCRIPTION
Fixed bug with AddEnemyToLevel with empty levelRarities ignoring non-empty customLevelRarities.

Rewrote AddEnemyToLevel to be cleaner, it was really messy.

Update changelog.

To test it i just turned on extended logging and looked at all the values, the problem was noticed when "vanilla:0,acidir:400" gave acidir a weight of 400 and "acidir:400" gave acidir no weights, but now it does, and it's the right one.